### PR TITLE
feat(api/index AUTH0): add authenticaction method

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -19,10 +19,33 @@
 //     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const server = require('./src/app.js');
 const { conn } = require('./src/db.js');
+const port = process.env.PORT || 3000;
+require('dotenv').config();
+const { auth, requiresAuth } = require('express-openid-connect');
+
+server.use(
+  auth({
+    authRequired: false,
+    auth0Logout: true,
+    issuerBaseURL: process.env.ISSUER_BASE_URL ,
+    baseURL: process.env.BASE_URL ,
+    clientID: process.env.CLIENT_ID ,
+    secret: process.env.SECRET ,
+    idpLogout: true,
+  })
+);
+
+server.get('/', (req, res) => {
+  res.send(req.oidc.isAuthenticated() ? "Logged in" : "Logged Out")
+});
+
+server.get('/profile', requiresAuth(), (req, res) => {  //This route reauieres to be authenticated to be able to get it
+  res.send(JSON.stringify(req.oidc.user));
+});
 
 // Syncing all the models at once.
-conn.sync({ force: true }).then(() => {
-  server.listen(3001, () => {
-    console.log('%s listening at 3001'); // eslint-disable-line no-console
+//conn.sync({ force: true }).then(() => {  // COMENTADO PARA PODER LEVANTAR LA APP SIN DB
+  server.listen(port, () => {
+    console.log(`Server listening at Port ${port}`); // eslint-disable-line no-console
   });
-});
+//});

--- a/api/package.json
+++ b/api/package.json
@@ -22,7 +22,8 @@
     "morgan": "^1.10.0",
     "pg": "^8.5.1",
     "sequelize": "^6.3.5",
-    "nodemon": "^2.0.6"
+    "nodemon": "^2.0.6",
+    "express-openid-connect": "^2.8.0"
 
   },
   "devDependencies": {

--- a/api/src/db.js
+++ b/api/src/db.js
@@ -14,7 +14,7 @@ const basename = path.basename(__filename);
 
 const modelDefiners = [];
 
-// Leemos todos los archivos de la carpeta Models, los requerimos y agregamos al arreglo modelDefiners
+// Leemos todos los archivos de la carpeta Models, los requerimos y agregamos al arreglo modelDefiners 
 fs.readdirSync(path.join(__dirname, '/models'))
   .filter((file) => (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js'))
   .forEach((file) => {

--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -1,4 +1,5 @@
 const { Router } = require('express');
+const { auth, requiresAuth } = require('express-openid-connect'); // se usa con el middleware para securizar las rutas que requieren autenticación
 // Importar todos los routers;
 // Ejemplo: const authRouter = require('./auth.js');
 


### PR DESCRIPTION
Just added the AUTH 0 authentication method to the index file in api. The method requieres that any user that pretends to acces certain protected routes are requiered a validation process that certifies identity and returns back user credentials. Still need to work out how to register that credentials on our own database.

index.js:
const port = process.env.PORT || 3000;
require('dotenv').config();
const { auth, requiresAuth } = require('express-openid-connect');

server.use(
  auth({
    authRequired: false,
    auth0Logout: true,
    issuerBaseURL: process.env.ISSUER_BASE_URL ,
    baseURL: process.env.BASE_URL ,
    clientID: process.env.CLIENT_ID ,
    secret: process.env.SECRET ,
    idpLogout: true,
  })
);