### PR TITLE
fix(client/Actions & api/app):fixed isuue port 3000

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -15,7 +15,7 @@ server.use(bodyParser.json({ limit: '50mb' }));
 server.use(cookieParser());
 server.use(morgan('dev'));
 server.use((req, res, next) => {
-  res.header('Access-Control-Allow-Origin', 'http://localhost:3001'); // update to match the domain you will make the request from
+  res.header('Access-Control-Allow-Origin', 'http://localhost:3000'); // update to match the domain you will make the request from
   res.header('Access-Control-Allow-Credentials', 'true');
   res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
   res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, DELETE');


### PR DESCRIPTION
This fix allows for backend to run on port 3001 and levaes the front to use the standard 3000.
I had to modify line 18 on api/src/app.js  to: 
" res.header('Access-Control-Allow-Origin', 'http://localhost:3000');",
In the future we will have to modify it again to match the new url when we deply this app.

beside the routes on the Actions file need to be changed to match the selected port on api to 3001 on line 8 and future back calls.